### PR TITLE
Fixing SSR bug in ModelStore rendering children

### DIFF
--- a/src/ModelStore.ts
+++ b/src/ModelStore.ts
@@ -153,10 +153,10 @@ export class ModelStore {
 
         const isItem = PathUtils.isItem(path);
 
-         if (!isItem && this._data) {
+        if (!isItem && this._data) {
 
             // Page data
-            if(!this._data[Constants.CHILDREN_PROP]){
+            if (!this._data[Constants.CHILDREN_PROP]){
                 this._data[Constants.CHILDREN_PROP] = {};
             }
             // @ts-ignore

--- a/src/ModelStore.ts
+++ b/src/ModelStore.ts
@@ -153,8 +153,12 @@ export class ModelStore {
 
         const isItem = PathUtils.isItem(path);
 
-        if (!isItem && this._data && this._data[Constants.CHILDREN_PROP]) {
+         if (!isItem && this._data) {
+
             // Page data
+            if(!this._data[Constants.CHILDREN_PROP]){
+                this._data[Constants.CHILDREN_PROP] = {};
+            }
             // @ts-ignore
             this._data[Constants.CHILDREN_PROP][path] = data;
 


### PR DESCRIPTION
Fixed a bug for SSR mode where the children prop was not initialized and therefore nothing was rendered.