### PR TITLE
ci(sonarcloud): upload report on merging to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,18 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
       - name: Install dependencies
         run: npm ci
-      - name: Run tests and do code coverage check
-        run: npm run test:coverage
       - name: Build the project
         run: npm run build:production
+      - name: Run tests and do code coverage check
+        run: npm run test:coverage
       - name: Upload code coverage report to codecov.io
         uses: codecov/codecov-action@v1
       - name: Upload Sonar report to sonarcloud.io


### PR DESCRIPTION
- change the order of steps (first build, then do test coverage, otherwise reports will be deleted)
- checkout repo with full depth (to fully benefit from sonar reports)