### PR TITLE
fix: fetch page model on back nav

### DIFF
--- a/src/ModelRouter.ts
+++ b/src/ModelRouter.ts
@@ -203,4 +203,11 @@ if (isModelRouterEnabled()) {
 
         return replaceState.apply(history, [ state, title, url ]);
     };
+
+    window.onpopstate = (history: any) => {
+        const currentPath = history?.target?.location?.pathname;
+
+        routeModel(currentPath || null);
+    };
+
 }


### PR DESCRIPTION
On back navigation, empty page is rendered if model is unavailable. To resolve this, model of the
page is fetched and page is rendered.

Fixes #28