### PR TITLE
fix: add check to handle removed properties

### DIFF
--- a/src/ModelStore.ts
+++ b/src/ModelStore.ts
@@ -92,14 +92,9 @@ export class ModelStore {
             if (data && data[Constants.ITEMS_PROP]) {
                 const localData = clone(newData);
                 const items = data[Constants.ITEMS_PROP] || {};
-                const oldData = items[itemKey];
-                
-                for (const property in oldData) {
-                    if (!localData.value[property]) {
-                        localData.value[property] = "";
-                    }
-                }
-                
+
+                Object.keys(items[itemKey]).forEach(x => localData.value[x] = localData.value[x] || '');
+
                 items[itemKey] = localData.value;
                 data[Constants.ITEMS_PROP] = items;
             }

--- a/src/ModelStore.ts
+++ b/src/ModelStore.ts
@@ -92,7 +92,14 @@ export class ModelStore {
             if (data && data[Constants.ITEMS_PROP]) {
                 const localData = clone(newData);
                 const items = data[Constants.ITEMS_PROP] || {};
-
+                const oldData = items[itemKey];
+                
+                for (const property in oldData) {
+                    if (!localData.value[property]) {
+                        localData.value[property] = "";
+                    }
+                }
+                
                 items[itemKey] = localData.value;
                 data[Constants.ITEMS_PROP] = items;
             }

--- a/test/ModelStore.test.ts
+++ b/test/ModelStore.test.ts
@@ -36,6 +36,8 @@ interface MutableModel extends Model{
 
 describe('ModelStore ->', () => {
     const modelStore: ModelStore = new ModelStore('/');
+    const TEST_FIELD = 'testField';
+    const TEST_FIELD_DATA = 'testData';
 
     beforeEach(() => {
         const cloned: Model = clone(PAGE_MODEL);
@@ -188,43 +190,33 @@ describe('ModelStore ->', () => {
     describe('setData', () => {
         it('should set data', () => {
             let item: any = modelStore.getData('/content/test/child_page_1/jcr:content/root/child1000');
-
-            expect(item).toBeDefined();
-            item['testField'] = 'testData';
-
+            item[TEST_FIELD] = TEST_FIELD_DATA;
             const val = {
                 key: 'child1000',
                 value: item
             };
 
             modelStore.setData('/content/test/child_page_1/jcr:content/root/child1000', val);
+
             item = modelStore.getData('/content/test/child_page_1/jcr:content/root/child1000');
-            expect(item['testField']).toEqual('testData');
+            expect(item[TEST_FIELD]).toEqual(TEST_FIELD_DATA);
         });
 
         it('should set empty string on removed data', () => {
             let item: any = modelStore.getData('/content/test/child_page_1/jcr:content/root/child1000');
-
-            expect(item).toBeDefined();
-            item['testField'] = 'testData';
-
-            let val = {
+            item[TEST_FIELD] = TEST_FIELD_DATA;
+            const val = {
                 key: 'child1000',
                 value: item
             };
-
             modelStore.setData('/content/test/child_page_1/jcr:content/root/child1000', val);
 
-            const newitem = clone(item);
-
-            delete newitem['testField'];
-            val = {
-                key: 'child1000',
-                value: newitem
-            };
+            delete item[TEST_FIELD];
+            val.value = item;
             modelStore.setData('/content/test/child_page_1/jcr:content/root/child1000', val);
+
             item = modelStore.getData('/content/test/child_page_1/jcr:content/root/child1000');
-            expect(item['testField']).toEqual('');
+            expect(item[TEST_FIELD]).toEqual('');
         });
     });
 

--- a/test/ModelStore.test.ts
+++ b/test/ModelStore.test.ts
@@ -185,6 +185,49 @@ describe('ModelStore ->', () => {
         });
     });
 
+    describe('setData', () => {
+        it('should set data', () => {
+            let item: any = modelStore.getData('/content/test/child_page_1/jcr:content/root/child1000');
+
+            expect(item).toBeDefined();
+            item['testField'] = 'testData';
+
+            const val = {
+                key: 'child1000',
+                value: item
+            };
+
+            modelStore.setData('/content/test/child_page_1/jcr:content/root/child1000', val);
+            item = modelStore.getData('/content/test/child_page_1/jcr:content/root/child1000');
+            expect(item['testField']).toEqual('testData');
+        });
+
+        it('should set empty string on removed data', () => {
+            let item: any = modelStore.getData('/content/test/child_page_1/jcr:content/root/child1000');
+
+            expect(item).toBeDefined();
+            item['testField'] = 'testData';
+
+            let val = {
+                key: 'child1000',
+                value: item
+            };
+
+            modelStore.setData('/content/test/child_page_1/jcr:content/root/child1000', val);
+
+            const newitem = clone(item);
+
+            delete newitem['testField'];
+            val = {
+                key: 'child1000',
+                value: newitem
+            };
+            modelStore.setData('/content/test/child_page_1/jcr:content/root/child1000', val);
+            item = modelStore.getData('/content/test/child_page_1/jcr:content/root/child1000');
+            expect(item['testField']).toEqual('');
+        });
+    });
+
     describe('removeData', () => {
         it('should remove a page', () => {
             expect(modelStore.getData()![Constants.CHILDREN_PROP] && modelStore.getData()![Constants.CHILDREN_PROP]).toHaveProperty('/content/test/subpage2');


### PR DESCRIPTION
- On removing a property (removing text from text component or clearing image from image component), its not not passed to ModelManager which returns update data to component without the property. 
- Each component only checks the received properties from ModelManager for updating its state
- This causes issues where the removed property is still visible on page (https://github.com/adobe/aem-angular-editable-components/issues/20)

This fix adds a null string to removed properties so they can be removed from page after editing
