### PR TITLE
Issue/remote app edit

### DIFF
--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -61,6 +61,11 @@ interface ModelPaths {
     metaPropertyModelURL?: string;
 }
 
+interface ParentPage {
+    pagePath: string;
+    pageData?: Model;
+}
+
 /**
  * @private
  */
@@ -224,7 +229,7 @@ export class ModelManager {
         const pageModelRoot = PathUtils.getMetaPropertyValue(MetaProperty.PAGE_MODEL_ROOT_URL);
         const metaPropertyModelURL = PathUtils.internalize(pageModelRoot);
 
-        const currentPathname = !this._isRemoteApp() ? PathUtils.getCurrentPathname() : '';
+        const currentPathname = this._isRemoteApp() ? '' : PathUtils.getCurrentPathname();
         // For remote apps in edit mode, to fetch path via parent URL
 
         const sanitizedCurrentPathname = ((currentPathname && PathUtils.sanitize(currentPathname)) || '') as string;
@@ -573,9 +578,8 @@ export class ModelManager {
      * 1. Parent page path
      * 2. Parent page data if already available in the store
      * @return {object}
-     * @private
      */
-    private _fetchParentPage(path: string) {
+    private _fetchParentPage(path: string): ParentPage {
         const dataPaths = PathUtils.splitPageContentPaths(path);
         const pagePath = dataPaths?.pagePath || '';
         const pageData = this.modelStore.getData(pagePath);
@@ -588,13 +592,12 @@ export class ModelManager {
 
     /**
      * Checks if the currently open app in aem editor is a remote app
-     * @private
      * @returns true if remote app
      */
-    private _isRemoteApp() {
-        const aemApiHost = this.modelClient.apiHost;
+    public _isRemoteApp(): boolean {
+        const aemApiHost = this.modelClient.apiHost || '';
 
-        return PathUtils.isBrowser() && aemApiHost && (PathUtils.getCurrentURL() !== aemApiHost);
+        return (PathUtils.isBrowser() && aemApiHost.length > 0 && (PathUtils.getCurrentURL() !== aemApiHost));
     }
 }
 

--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -61,7 +61,7 @@ interface ModelPaths {
     metaPropertyModelURL?: string;
 }
 
-interface ParentPage {
+interface Page {
     pagePath: string;
     pageData?: Model;
 }
@@ -368,7 +368,7 @@ export class ModelManager {
                 // 1.Fetch the page data and store it
                 // 2.Return the required item data from the fetched page data
                 if (PathUtils.isItem(path)) {
-                    const { pageData, pagePath } = this._fetchParentPage(path);
+                    const { pageData, pagePath } = this._getParentPage(path);
 
                     if (!pageData) {
                         return this._fetchData(pagePath).then((data: Model) => {
@@ -579,7 +579,7 @@ export class ModelManager {
      * 2. Parent page data if already available in the store
      * @return {object}
      */
-    private _fetchParentPage(path: string): ParentPage {
+    private _getParentPage(path: string): Page {
         const dataPaths = PathUtils.splitPageContentPaths(path);
         const pagePath = dataPaths?.pagePath || '';
         const pageData = this.modelStore.getData(pagePath);

--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -359,13 +359,6 @@ export class ModelManager {
                     }
                 }
 
-                const fetchDataPromise = (path: string, itemPath?: string) => this._fetchData(path).then((data: Model) => {
-                    this._storeData(path, data);
-                    if (itemPath) {
-                        this.modelStore.getData(path);
-                    }
-                });
-
                 // If data to be fetched for a component in a page not yet retrieved
                 // 1.Fetch the page data and store it
                 // 2.Return the required item data from the fetched page data
@@ -373,11 +366,15 @@ export class ModelManager {
                     const { pageData, pagePath } = this._fetchParentPage(path);
 
                     if (!pageData) {
-                        return fetchDataPromise(pagePath, path);
+                        return this._fetchData(pagePath).then((data: Model) => {
+                            this._storeData(pagePath, data);
+
+                            return this.modelStore.getData(path);
+                        });
                     }
                 }
 
-                return fetchDataPromise(path);
+                return this._fetchData(path).then((data: Model) => this._storeData(path, data));
         });
     }
 

--- a/src/ModelStore.ts
+++ b/src/ModelStore.ts
@@ -93,7 +93,9 @@ export class ModelStore {
                 const localData = clone(newData);
                 const items = data[Constants.ITEMS_PROP] || {};
 
-                Object.keys(items[itemKey]).forEach(x => localData.value[x] = localData.value[x] || '');
+                if (items[itemKey]) {
+                    Object.keys(items[itemKey]).forEach(x => localData.value[x] = localData.value[x] || '');
+                }
 
                 items[itemKey] = localData.value;
                 data[Constants.ITEMS_PROP] = items;

--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -15,7 +15,6 @@ import url from 'url';
 import Constants from './Constants';
 import InternalConstants from './InternalConstants';
 import MetaProperty from './MetaProperty';
-import { AuthoringUtils } from './AuthoringUtils';
 
 /**
  * Regexp used to extract the context path of a location.
@@ -529,13 +528,10 @@ export class PathUtils {
         const isLoadedInAEM = window.location.origin === aemHost;
 
         if (isLoadedInAEM) {
-            const isAuthoring = AuthoringUtils.isStateActive(Constants.STATE_AUTHORING);
-            const editorPrefix = isAuthoring ? '(/editor.html)?' : '';
-
-            const aemPathPrefix = `${editorPrefix}/content/${rootPath}`;
+            const aemPathPrefix = `(/editor.html)?/content/${rootPath}`;
 
             if (path.indexOf(aemPathPrefix) < 0) {
-                const newPath = normalizePath(`${aemPathPrefix}${path}(.html)?`);
+                const newPath = normalizePath(`${aemPathPrefix}/${path}(.html)?`);
 
                 return newPath;
             }

--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -522,22 +522,23 @@ export class PathUtils {
      * @param path Path to route to
      * @param aemHost Origin information of the AEM instance in which to edit
      * @param rootPath AEM path which forms the root path of the remote app
-     * @private
      * @returns Updated url
      */
     public static toAEMPath(path: string, aemHost: string, rootPath: string): string {
         const isLoadedInAEM = window.location.origin === aemHost;
 
         if (isLoadedInAEM) {
-            const wcmMode = PathUtils.getMetaPropertyValue("cq:wcmmode");
+            const wcmMode = PathUtils.getMetaPropertyValue('cq:wcmmode');
             const isEditorMode = wcmMode === 'edit';
             const editorPrefix = isEditorMode ? '(/editor.html)?' : '';
 
-            const aemPathPrefix = `/content/${rootPath}`;
+            const aemPathPrefix = `${editorPrefix}/content/${rootPath}`;
 
-            const newPath = normalizePath(`${editorPrefix}${aemPathPrefix}${path}(.html)?`);
+            if (path.indexOf(aemPathPrefix) < 0) {
+                const newPath = normalizePath(`${aemPathPrefix}${path}(.html)?`);
 
-            return newPath;
+                return newPath;
+            }
         }
 
         return path;

--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -529,7 +529,7 @@ export class PathUtils {
         const isLoadedInAEM = window.location.origin === aemHost;
 
         if (isLoadedInAEM) {
-            const wcmMode = document.head.querySelector('meta[property="cq:wcmmode"]')?.getAttribute('content');
+            const wcmMode = PathUtils.getMetaPropertyValue("cq:wcmmode");
             const isEditorMode = wcmMode === 'edit';
             const editorPrefix = isEditorMode ? '(/editor.html)?' : '';
 

--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -15,6 +15,7 @@ import url from 'url';
 import Constants from './Constants';
 import InternalConstants from './InternalConstants';
 import MetaProperty from './MetaProperty';
+import { AuthoringUtils } from './AuthoringUtils';
 
 /**
  * Regexp used to extract the context path of a location.
@@ -528,9 +529,8 @@ export class PathUtils {
         const isLoadedInAEM = window.location.origin === aemHost;
 
         if (isLoadedInAEM) {
-            const wcmMode = PathUtils.getMetaPropertyValue('cq:wcmmode');
-            const isEditorMode = wcmMode === 'edit';
-            const editorPrefix = isEditorMode ? '(/editor.html)?' : '';
+            const isAuthoring = AuthoringUtils.isStateActive(Constants.STATE_AUTHORING);
+            const editorPrefix = isAuthoring ? '(/editor.html)?' : '';
 
             const aemPathPrefix = `${editorPrefix}/content/${rootPath}`;
 

--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -516,4 +516,30 @@ export class PathUtils {
 
         return PathUtils.makeRelative(returnStr);
     }
+
+    /**
+     * Helper for handling remote react app routing in edit mode
+     * @param path Path to route to
+     * @param aemHost Origin information of the AEM instance in which to edit
+     * @param rootPath AEM path which forms the root path of the remote app
+     * @private
+     * @returns Updated url
+     */
+    public static toAEMPath(path: string, aemHost: string, rootPath: string): string {
+        const isLoadedInAEM = window.location.origin === aemHost;
+
+        if (isLoadedInAEM) {
+            const wcmMode = document.head.querySelector('meta[property="cq:wcmmode"]')?.getAttribute('content');
+            const isEditorMode = wcmMode === 'edit';
+            const editorPrefix = isEditorMode ? '(/editor.html)?' : '';
+
+            const aemPathPrefix = `/content/${rootPath}`;
+
+            const newPath = normalizePath(`${editorPrefix}${aemPathPrefix}${path}(.html)?`);
+
+            return newPath;
+        }
+
+        return path;
+    }
 }

--- a/test/ModelManager.test.ts
+++ b/test/ModelManager.test.ts
@@ -263,6 +263,15 @@ describe('ModelManager ->', () => {
             });
         });
 
+        it('should fetch standalone item data', () => {
+            metaProps = {};
+            pathName = '';
+            ModelManager.initializeAsync();
+
+            return ModelManager.getData({ path: CHILD_PATH }).then((data) => {
+                assert.deepEqual(data, content_test_page_root_child0000_child0010, 'data should be correct');
+            });
+        });
         it('should throw error when fetching data without initialization', () => {
             ModelManager.getData({ path: PAGE_MODEL_URL }).then((data) => {
                 assert.deepEqual(data, PAGE_MODEL, 'data should be correct');

--- a/test/PathUtils.test.ts
+++ b/test/PathUtils.test.ts
@@ -432,25 +432,35 @@ describe('PathUtils ->', () => {
         assert.equal(PathUtils.getParentNodePath('/foobar/a/xyz'), '/foobar/a');
     });
 
-    describe('toAemPath', () => {
-        it('transform remote react app path to AEM path', () => {
-            const AEM_ORIGIN = window.location.origin;
-            const REMOTE_APP_PAGE = '/page';
-            const AEM_ROOT_PATH = 'testproj/lang';
-            const AEM_PAGE_PATH = `/content/${AEM_ROOT_PATH}/page.html`;
+    describe('toAEMPath', () => {
+        const AEM_ORIGIN = window.location.origin;
+        const REMOTE_APP_PAGE = '/page';
+        const AEM_ROOT_PATH = 'testproj/lang';
+        let AEM_PAGE_PATH = `/content/${AEM_ROOT_PATH}/page.html`;
 
+        it('transform remote react app path to AEM path', () => {
             // Transform to match AEM path when running on AEM instance
-            let newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
+            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
 
             expect(AEM_PAGE_PATH).toMatch(newPathPattern);
+        });
+        it('transform remote react app path to AEM path on edit mode', () => {
+            AEM_PAGE_PATH = `/editor.html/content/${AEM_ROOT_PATH}/page.html`;
+            metaProps[MetaProperty.WCM_MODE] = 'edit';
 
+            // Transform to match AEM path when running on AEM instance
+            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
+
+            expect(AEM_PAGE_PATH).toMatch(newPathPattern);
+        });
+        it('returns original path on remote domain', () => {
             const REMOTE_ORIGIN = 'http://mydomain';
             const windowSpy: jest.SpyInstance = jest.spyOn(global, 'window', 'get');
 
             windowSpy.mockImplementation(() => ({ location: { origin: REMOTE_ORIGIN } }));
 
             // return actual path when app is running on a remote domain
-            newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
+            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
             windowSpy.mockRestore();
 
             expect(REMOTE_APP_PAGE).toMatch(newPathPattern);

--- a/test/PathUtils.test.ts
+++ b/test/PathUtils.test.ts
@@ -439,9 +439,21 @@ describe('PathUtils ->', () => {
             const AEM_ROOT_PATH = 'testproj/lang';
             const AEM_PAGE_PATH = `/content/${AEM_ROOT_PATH}/page.html`;
 
-            const newPathPattern =  new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
+            // Transform to match AEM path when running on AEM instance
+            let newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
 
             expect(AEM_PAGE_PATH).toMatch(newPathPattern);
+
+            const REMOTE_ORIGIN = 'http://mydomain';
+            const windowSpy: jest.SpyInstance = jest.spyOn(global, 'window', 'get');
+
+            windowSpy.mockImplementation(() => ({ location: { origin: REMOTE_ORIGIN } }));
+
+            // return actual path when app is running on a remote domain
+            newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
+            windowSpy.mockRestore();
+
+            expect(REMOTE_APP_PAGE).toMatch(newPathPattern);
         });
     });
 });

--- a/test/PathUtils.test.ts
+++ b/test/PathUtils.test.ts
@@ -433,25 +433,28 @@ describe('PathUtils ->', () => {
     });
 
     describe('toAEMPath', () => {
-        const AEM_ORIGIN = window.location.origin;
         const REMOTE_APP_PAGE = '/page';
         const AEM_ROOT_PATH = 'testproj/lang';
-        let AEM_PAGE_PATH = `/content/${AEM_ROOT_PATH}/page.html`;
+        const AEM_PAGE_PATH = `/content/${AEM_ROOT_PATH}/page.html`;
+        let aemOrigin: string;
+
+        beforeAll(() => {
+            aemOrigin = window.location.origin;
+        });
 
         it('transform remote react app path to AEM path', () => {
             // Transform to match AEM path when running on AEM instance
-            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
-
+            const newPathPattern =  new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, aemOrigin, AEM_ROOT_PATH));
             expect(AEM_PAGE_PATH).toMatch(newPathPattern);
         });
         it('transform remote react app path to AEM path on edit mode', () => {
-            AEM_PAGE_PATH = `/editor.html/content/${AEM_ROOT_PATH}/page.html`;
+            const AEM_EDIT_PATH = `/editor.html${AEM_PAGE_PATH}`;
             metaProps[MetaProperty.WCM_MODE] = 'edit';
 
             // Transform to match AEM path when running on AEM instance
-            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
+            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, aemOrigin, AEM_ROOT_PATH));
 
-            expect(AEM_PAGE_PATH).toMatch(newPathPattern);
+            expect(AEM_EDIT_PATH).toMatch(newPathPattern);
         });
         it('returns original path on remote domain', () => {
             const REMOTE_ORIGIN = 'http://mydomain';
@@ -460,7 +463,7 @@ describe('PathUtils ->', () => {
             windowSpy.mockImplementation(() => ({ location: { origin: REMOTE_ORIGIN } }));
 
             // return actual path when app is running on a remote domain
-            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
+            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, aemOrigin, AEM_ROOT_PATH));
             windowSpy.mockRestore();
 
             expect(REMOTE_APP_PAGE).toMatch(newPathPattern);

--- a/test/PathUtils.test.ts
+++ b/test/PathUtils.test.ts
@@ -444,11 +444,13 @@ describe('PathUtils ->', () => {
 
         it('transform remote react app path to AEM path', () => {
             // Transform to match AEM path when running on AEM instance
-            const newPathPattern =  new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, aemOrigin, AEM_ROOT_PATH));
+            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, aemOrigin, AEM_ROOT_PATH));
+
             expect(AEM_PAGE_PATH).toMatch(newPathPattern);
         });
         it('transform remote react app path to AEM path on edit mode', () => {
             const AEM_EDIT_PATH = `/editor.html${AEM_PAGE_PATH}`;
+
             metaProps[MetaProperty.WCM_MODE] = 'edit';
 
             // Transform to match AEM path when running on AEM instance
@@ -464,6 +466,7 @@ describe('PathUtils ->', () => {
 
             // return actual path when app is running on a remote domain
             const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, aemOrigin, AEM_ROOT_PATH));
+
             windowSpy.mockRestore();
 
             expect(REMOTE_APP_PAGE).toMatch(newPathPattern);

--- a/test/PathUtils.test.ts
+++ b/test/PathUtils.test.ts
@@ -431,4 +431,17 @@ describe('PathUtils ->', () => {
         assert.equal(PathUtils.getParentNodePath('/foobar'), '');
         assert.equal(PathUtils.getParentNodePath('/foobar/a/xyz'), '/foobar/a');
     });
+
+    describe('toAemPath', () => {
+        it('transform remote react app path to AEM path', () => {
+            const AEM_ORIGIN = window.location.origin;
+            const REMOTE_APP_PAGE = '/page';
+            const AEM_ROOT_PATH = 'testproj/lang';
+            const AEM_PAGE_PATH = `/content/${AEM_ROOT_PATH}/page.html`;
+
+            const newPathPattern =  new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, AEM_ORIGIN, AEM_ROOT_PATH));
+
+            expect(AEM_PAGE_PATH).toMatch(newPathPattern);
+        });
+    });
 });


### PR DESCRIPTION
- `toAEMPath`: Added new helper for transforming remote path to AEM specific path for enabling routing.This is a stop gap solution and will be removed later.
- Issue fixes for enabling edit of remote component in AEM instance