### PR TITLE
Aem editable remote spa

### DIFF
--- a/src/AuthoringUtils.ts
+++ b/src/AuthoringUtils.ts
@@ -186,7 +186,7 @@ export class AuthoringUtils {
         const domain = this.getApiDomain();
 
         libraries.forEach((library) => {
-            result.push(`${domain ? domain : ''}${library}`);
+            result.push(`${domain || ''}${library}`);
         });
 
         return result;

--- a/src/AuthoringUtils.ts
+++ b/src/AuthoringUtils.ts
@@ -55,14 +55,14 @@ export class AuthoringUtils {
     }
 
     /**
-     * Generates <script> and <link> tags.
+     * Generates <script>, <link> and <meta> tags.
      * The document fragment needs to be added to the page to enable AEM Editing capabilities.
      *
      * Example:
      * ```
      * import ModelManager, Constants, { AEM_MODE } from '@adobe/aem-spa-page-model-manager';
      *
-     * await ModelManager.initialize({modelClient: new ModelClient(REMOTE_AEM_HOST)});
+     * await ModelManager.initialize({modelClient: new ModelClient(<<REMOTE_AEM_HOST>>)});
      * const docFragment = ModelManager.clientlibUtil.getAemLibraries();
      * window.document.head.appendChild(docFragment);
      * ```
@@ -123,9 +123,9 @@ export class AuthoringUtils {
     }
 
     /**
-     * Checks AEM mode.
+     * Checks AEM mode from URL.
      * @private
-     * @returns AEM mode or `null`.
+     * @returns AEM mode.
      */
     private static getAemMode(): string {
         let url: URL;

--- a/src/AuthoringUtils.ts
+++ b/src/AuthoringUtils.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import Constants, { AEM_MODE, TAG_ATTR, TAG_TYPE } from './Constants';
+import Constants, { AEM_MODE, TAG_TYPE } from './Constants';
 import { PathUtils } from './PathUtils';
 import MetaProperty from './MetaProperty';
 
@@ -28,7 +28,7 @@ export class AuthoringUtils {
      * @private
      */
     getApiDomain(): string | null {
-        return this._apiDomain;
+        return 'http://localhost:4502';
     }
 
     /**
@@ -51,20 +51,40 @@ export class AuthoringUtils {
      *
      * @returns HTML markup including state specific libraries.
      */
-    public getTagsForState(appState: string): string {
-        let tags = '';
+    public getTagsForState(appState: string): string[] {
+        let tags: string[] = [];
 
-        if (appState === Constants.STATE_AUTHORING) {
-            const clientLibs = this.generateClientLibUrls();
+        // if (appState === Constants.STATE_AUTHORING) {
+        const clientLibs = this.generateClientLibUrls();
+        console.log(appState);
+        tags = clientLibs//.map(resource => {
+            // if (resource.endsWith('.js')) {
+            //     return this.generateElementString(TAG_TYPE.JS, TAG_ATTR.SRC, resource);
+            // }
+       //  })
+        .filter(resource => {
+            return resource.endsWith('.js');
+        }) as string[];
+        // }
 
-            tags = clientLibs.map(resource => {
-                if (resource.endsWith('.js')) {
-                    return this.generateElementString(TAG_TYPE.JS, TAG_ATTR.SRC, resource);
-                } else if (resource.endsWith('.css')) {
-                    return this.generateElementString(TAG_TYPE.STYLESHEET, TAG_ATTR.HREF, resource);
-                }
-            }).join('');
-        }
+        return tags;
+    }
+
+    public getCssTagsForState(appState: string): string[] {
+        let tags: string[] = [];
+
+        // if (appState === Constants.STATE_AUTHORING) {
+        const clientLibs = this.generateClientLibUrls();
+        console.log(appState);
+        tags = clientLibs//.map(resource => {
+        //     if (resource.endsWith('.css')) {
+        //         return this.generateElementString(TAG_TYPE.STYLESHEET, TAG_ATTR.HREF, resource);
+        //     }
+        // })
+        .filter(resource => {
+            return resource.endsWith('.css');
+        }) as string[];
+        // // }
 
         return tags;
     }
@@ -128,11 +148,11 @@ export class AuthoringUtils {
         const result: string[] = [];
         const domain = this.getApiDomain();
 
-        if (domain) {
-            Constants.AUTHORING_LIBRARIES.forEach((library) => {
-                result.push(`${domain}${Constants.EDITOR_CLIENTLIB_PATH}${library}`);
-            });
-        }
+        // if (domain) {
+        Constants.AUTHORING_LIBRARIES.forEach((library) => {
+            result.push(`${domain}${Constants.EDITOR_CLIENTLIB_PATH}${library}`);
+        });
+        // }
 
         return result;
     }

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -63,16 +63,17 @@ export class Constants {
     /**
      * Base path for editor clientlibs.
      */
-    public static readonly EDITOR_CLIENTLIB_PATH = '/etc.clientlibs/cq/gui/components/authoring/editors/clientlibs/internal/';
+    public static readonly EDITOR_CLIENTLIB_PATH = '/etc.clientlibs/cq/gui/components/authoring/editors/clientlibs/';
 
     /**
      * Authoring libraries.
      */
     public static readonly AUTHORING_LIBRARIES = [
-        'page.js',
-        'page.css',
-        'pagemodel/messaging.js',
-        'messaging.js'
+        'internal/messaging.js',
+        'utils.js',
+        'internal/page.js',
+        'internal/page.css',
+        'internal/pagemodel/messaging.js'
     ];
 
     private constructor() {

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -50,32 +50,6 @@ export class Constants {
      */
     public static readonly JCR_CONTENT = 'jcr:content';
 
-    /**
-     * AEM state `authoring`.
-     */
-    public static readonly STATE_AUTHORING = 'authoring';
-
-    /**
-     * Flag name (query parameter) to determine AEM mode.
-     */
-    public static readonly AEM_MODE_KEY = 'aemmode';
-
-    /**
-     * Base path for editor clientlibs.
-     */
-    public static readonly EDITOR_CLIENTLIB_PATH = '/etc.clientlibs/cq/gui/components/authoring/editors/clientlibs/';
-
-    /**
-     * Authoring libraries.
-     */
-    public static readonly AUTHORING_LIBRARIES = [
-        'internal/messaging.js',
-        'utils.js',
-        'internal/page.js',
-        'internal/page.css',
-        'internal/pagemodel/messaging.js'
-    ];
-
     private constructor() {
         // hide constructor
     }
@@ -97,15 +71,6 @@ export enum AEM_MODE {
 export enum TAG_TYPE {
     JS = 'script',
     STYLESHEET = 'stylesheet'
-}
-
-/**
- * Supported tag attributes.
- * @private
- */
-export enum TAG_ATTR {
-    SRC = 'src',
-    HREF = 'href'
 }
 
 export default Constants;

--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -193,6 +193,7 @@ export class ModelManager {
         const initialModel = modelConfig && modelConfig.model;
 
         this._initializeFields(modelConfig);
+        this._attachAEMLibraries();
 
         const { rootModelPath } = this._modelPaths;
 
@@ -200,6 +201,20 @@ export class ModelManager {
 
         if (rootModelPath) {
             this._setInitializationPromise(rootModelPath);
+        }
+
+    }
+
+    /**
+     * Attaches detected in runtime required libraries to enable special AEM authoring capabilities.
+     *
+     * @private
+     */
+    private _attachAEMLibraries() {
+        const docFragment = this.clientlibUtil.getAemLibraries();
+
+        if (window && docFragment.hasChildNodes()) {
+            window.document.head.appendChild(docFragment);
         }
     }
 

--- a/test/AuthoringUtils.test.ts
+++ b/test/AuthoringUtils.test.ts
@@ -12,307 +12,117 @@
 
 import * as assert from 'assert';
 import { AuthoringUtils } from '../src/AuthoringUtils';
-import Constants, { AEM_MODE, TAG_TYPE, TAG_ATTR } from '../src/Constants';
-import { PathUtils } from '../src/PathUtils';
+import {PathUtils} from "../src/PathUtils";
+import {AEM_MODE} from "../src/Constants";
+
 
 describe('AuthoringUtils ->', () => {
-    const authoringUtils = new AuthoringUtils('http://www.abc.com');
+    let authoringUtils: AuthoringUtils;
+
+    beforeEach(() => {
+        authoringUtils = new AuthoringUtils('http://www.abc.com');
+    });
 
     afterEach(() => {
         jest.restoreAllMocks();
     });
 
-    it('should return authoring clientlibs', () => {
-        // given
-        const expected = [
-            'http://www.abc.com/etc.clientlibs/cq/gui/components/authoring/editors/clientlibs/internal/page.js',
-            'http://www.abc.com/etc.clientlibs/cq/gui/components/authoring/editors/clientlibs/internal/page.css',
-            'http://www.abc.com/etc.clientlibs/cq/gui/components/authoring/editors/clientlibs/internal/pagemodel/messaging.js',
-            'http://www.abc.com/etc.clientlibs/cq/gui/components/authoring/editors/clientlibs/internal/messaging.js'
-        ];
+    describe('getAemLibraries', () => {
 
-        // when
-        const actual = authoringUtils.generateClientLibUrls();
-
-        // then
-        assert.deepStrictEqual(actual, expected);
-    });
-
-    it('should return empty array if domain is not provided', () => {
-        // given
-        jest.spyOn(authoringUtils, 'getApiDomain').mockReturnValue(null);
-
-        // when
-        const actual = authoringUtils.generateClientLibUrls();
-
-        // then
-        assert.deepStrictEqual(actual, []);
-    });
-
-    describe('generateElementString', () => {
-        let generateElementStringSpy: jest.SpyInstance<any, unknown[]>;
-
-        const mockParameters = (tagType: string, attr: string, attrValue: string) => {
+        it('should return empty DocumentFragment if not in edit mode', () => {
             // given
-             generateElementStringSpy = jest.spyOn(AuthoringUtils.prototype as any, 'generateElementString')
-                .mockImplementationOnce(() => generateElementStringSpy.getMockImplementation()(tagType, attr, attrValue));
+            jest.spyOn(AuthoringUtils, 'isEditMode').mockReturnValue(false);
+            // when
 
-            jest.spyOn(authoringUtils, 'generateClientLibUrls').mockReturnValue([ 'http://foo/dummy-request.js' ]);
+            const libs: DocumentFragment = authoringUtils.getAemLibraries();
+
+            // then
+            assert.ok(libs.hasChildNodes() === false);
+        });
+
+        it('should return DocumentFragment based on AuthoringUtils.AUTHORING_LIBRARIES', () => {
+            // given
+            jest.spyOn(AuthoringUtils, 'isEditMode').mockReturnValue(true);
 
             // when
-            authoringUtils.getTagsForState(Constants.STATE_AUTHORING);
-        };
 
-        it('should not generate any element if requested for empty tag name', () => {
-            // given and when
-            mockParameters('', 'src', 'foo');
+            const libs: DocumentFragment = authoringUtils.getAemLibraries();
 
             // then
-            expect(generateElementStringSpy).toHaveReturnedWith('');
+            assert.ok(libs.hasChildNodes());
+            assert.ok(libs.querySelectorAll('script').length === AuthoringUtils.AUTHORING_LIBRARIES.JS.length);
+            assert.ok(libs.querySelectorAll('link').length === AuthoringUtils.AUTHORING_LIBRARIES.CSS.length);
+            assert.ok(libs.querySelectorAll('meta').length === Object.entries(AuthoringUtils.AUTHORING_LIBRARIES.META).length);
         });
 
-        it('should not generate any element if requested for unsupported tag name', () => {
-            // given and when
-            mockParameters('', 'src', 'foo');
+        describe('scripts', () => {
+            it('should contain proper script tags', () => {
+                // given
+                jest.spyOn(AuthoringUtils, 'isEditMode').mockReturnValue(true);
+                // when
 
-            // then
-            expect(generateElementStringSpy).toHaveReturnedWith('');
+                const libs: DocumentFragment = authoringUtils.getAemLibraries();
+
+                // then
+                AuthoringUtils.AUTHORING_LIBRARIES.JS.forEach((scriptUrl) => {
+                    assert.ok(libs.querySelectorAll('script[src="' + scriptUrl + '"][type="text/javascript"]'));
+                });
+            });
+        });
+        describe('css', () => {
+            it('should contain proper css tags', () => {
+                // given
+                jest.spyOn(AuthoringUtils, 'isEditMode').mockReturnValue(true);
+                // when
+
+                const libs: DocumentFragment = authoringUtils.getAemLibraries();
+
+                // then
+                AuthoringUtils.AUTHORING_LIBRARIES.CSS.forEach((scriptUrl) => {
+                    assert.ok(libs.querySelectorAll('link[href="' + scriptUrl + '"][type="text/css"][rel="stylesheet"]'));
+                });
+            });
+        });
+        describe('meta', () => {
+            it('should contain proper meta tags', () => {
+                // given
+                jest.spyOn(AuthoringUtils, 'isEditMode').mockReturnValue(true);
+                // when
+
+                const libs: DocumentFragment = authoringUtils.getAemLibraries();
+
+                // then
+                Object.entries(AuthoringUtils.AUTHORING_LIBRARIES.META).forEach((entry) => {
+                    const [ key, val ] = entry;
+
+                    assert.ok(libs.querySelectorAll('meta[property="' + key + '"][content="' + val + '"]'));
+                });
+            });
         });
 
-        it('should generate element markup if requested for supported tag type (script)', () => {
-            // given and when
-            mockParameters(TAG_TYPE.JS, TAG_ATTR.SRC, 'foo.bar');
+    });
 
-            // then
-            expect(generateElementStringSpy).toHaveReturnedWith(`<script src="foo.bar"></script>`);
+    describe('isEditMode', () => {
+        it('should be false if both indicators are falsy', () => {
+            jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
+            jest.spyOn<any, string>(AuthoringUtils, 'getAemMode').mockReturnValue(null);
+
+            assert.ok(AuthoringUtils.isEditMode() === false);
         });
 
-        it('should generate element markup if requested for supported tag type (stylesheet)', () => {
-            // given and when
-            mockParameters(TAG_TYPE.STYLESHEET, TAG_ATTR.HREF, 'foo.bar');
+        it('should be true based on meta property', () => {
+            jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
+            jest.spyOn<any, string>(AuthoringUtils, 'getAemMode').mockReturnValue(null);
 
-            // then
-            expect(generateElementStringSpy).toHaveReturnedWith(`<link href="foo.bar"/>`);
+            assert.ok(AuthoringUtils.isEditMode());
+        });
+
+        it('should be true based on meta property', () => {
+            jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
+            jest.spyOn<any, string>(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.EDIT);
+
+            assert.ok(AuthoringUtils.isEditMode());
         });
     });
 
-    describe('getTagsForState', () => {
-        it('should return html tags if in authoring mode', () => {
-            // given
-            const clientLibUrls = [ 'http://foo/test.js', 'http://foo/test.css' ];
-            const expected = '<script src="http://foo/test.js"></script><link href="http://foo/test.css"/>';
-
-            jest.spyOn(authoringUtils, 'generateClientLibUrls').mockReturnValue(clientLibUrls);
-
-            // when
-            const actual = authoringUtils.getTagsForState(Constants.STATE_AUTHORING);
-
-            // then
-            assert.strictEqual(actual, expected);
-        });
-
-        it('should return empty string if not in authoring mode', () => {
-            // when
-            const actual = authoringUtils.getTagsForState('foobar');
-
-            // then
-            assert.strictEqual(actual, '');
-        });
-
-        it('should return empty string if unsupported resources were returned by `generateClientLibUrls`', () => {
-            // given
-            const clientLibUrls = [ 'http://foo/test.exe', 'http://foo/test.bat' ];
-
-            jest.spyOn(authoringUtils, 'generateClientLibUrls').mockReturnValue(clientLibUrls);
-
-            // when
-            const actual = authoringUtils.getTagsForState(Constants.STATE_AUTHORING);
-
-            // then
-            assert.strictEqual(actual, '');
-        });
-    });
-
-    describe('getAemMode', () => {
-        it('should return `aemmode` query parameter (preview)', () => {
-            // given
-            const actual = AEM_MODE.PREVIEW;
-
-            // when
-            jest.spyOn(PathUtils, 'getCurrentURL').mockReturnValue(`http://www.abc.com?aemmode=${actual}`);
-
-            // then
-            assert.strictEqual(AuthoringUtils.getAemMode(), actual);
-        });
-
-        it('should return `aemmode` query parameter (edit)', () => {
-            // given
-            const actual = AEM_MODE.EDIT;
-
-            // when
-            jest.spyOn(PathUtils, 'getCurrentURL').mockReturnValue(`http://www.abc.com?aemmode=${actual}`);
-
-            // then
-            assert.strictEqual(AuthoringUtils.getAemMode(), actual);
-        });
-
-        it('should return `null` if `aemmode` parameter is not provided', () => {
-            // when
-            jest.spyOn(PathUtils, 'getCurrentURL').mockReturnValue(`http://www.abc.com`);
-
-            // then
-            assert.strictEqual(AuthoringUtils.getAemMode(), null);
-        });
-
-        it('should return `null` if URL is malformed', () => {
-            // when
-            jest.spyOn(PathUtils, 'getCurrentURL').mockReturnValue(`foobar`);
-
-            // then
-            assert.strictEqual(AuthoringUtils.getAemMode(), null);
-        });
-    });
-
-    describe('isStateActive', () => {
-        describe('data from meta properties', () => {
-            it('should return `false` if: not in authoring mode and `aemmode` is `preview`', () => {
-                // given
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(null);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive('foo'), false);
-            });
-
-            it('should return `false` if: not in authoring mode and `aemmode` is `edit`', () => {
-                // given
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(null);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive('foo'), false);
-            });
-
-            it('should return `false` if: in authoring mode and `aemmode` is `preview`', () => {
-                // given
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(null);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive(Constants.STATE_AUTHORING), false);
-            });
-
-            it('should return `false` if: in authoring mode and `aemmode` is anything (except: edit)', () => {
-                // given
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue('foo');
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(null);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive(Constants.STATE_AUTHORING), false);
-            });
-
-            it('should return `true`: if in authoring mode and `aemmode` is `edit`', () => {
-                // given
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(null);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive(Constants.STATE_AUTHORING), true);
-            });
-        });
-
-        describe('data from query parameter', () => {
-            it('should return `false` if: not in authoring mode and `aemmode` is `preview`', () => {
-                // given
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(null);
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.PREVIEW);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive('foo'), false);
-            });
-
-            it('should return `false` if: not in authoring mode and `aemmode` is `edit`', () => {
-                // given
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(null);
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.EDIT);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive('foo'), false);
-            });
-
-            it('should return `false` if: in authoring mode and `aemmode` is `preview`', () => {
-                // given
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.PREVIEW);
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(null);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive(Constants.STATE_AUTHORING), false);
-            });
-
-            it('should return `false` if: in authoring mode and `aemmode` is anything (except: edit)', () => {
-                // given
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue('foo');
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(null);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive(Constants.STATE_AUTHORING), false);
-            });
-
-            it('should return `true`: if in authoring mode and `aemmode` is `edit`', () => {
-                // given
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.EDIT);
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(null);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive(Constants.STATE_AUTHORING), true);
-            });
-        });
-
-        describe('data from meta property and query parameter', () => {
-            it('should return `false` if: not in authoring mode and `aemmode` is `preview` (query parameter and meta property)', () => {
-                // given
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.PREVIEW);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive('foo'), false);
-            });
-
-            it('should return `false` if: not in authoring mode and `aemmode` is `edit` (query parameter and meta property)', () => {
-                // given
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.EDIT);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive('foo'), false);
-            });
-
-            it('should return `true` if: in authoring mode and `aemmode` is `preview` (query parameter) and `edit` (meta property)', () => {
-                // given
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.PREVIEW);
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive(Constants.STATE_AUTHORING), true);
-            });
-
-            it('should return `true` if: in authoring mode and `aemmode` is `edit` (query parameter) and `preview` (meta property)', () => {
-                // given
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.EDIT);
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive(Constants.STATE_AUTHORING), true);
-            });
-
-            it('should return `false`: if in authoring mode and `aemmode` is anything (query parameter) and anything (meta property)', () => {
-                // given
-                jest.spyOn(AuthoringUtils, 'getAemMode').mockReturnValue('foo');
-                jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue('foo');
-
-                // then
-                assert.strictEqual(AuthoringUtils.isStateActive(Constants.STATE_AUTHORING), false);
-            });
-        });
-    });
 });

--- a/test/AuthoringUtils.test.ts
+++ b/test/AuthoringUtils.test.ts
@@ -14,6 +14,7 @@ import * as assert from 'assert';
 import { AuthoringUtils } from '../src/AuthoringUtils';
 import { PathUtils } from '../src/PathUtils';
 import { AEM_MODE } from '../src/Constants';
+import MetaProperty from "../src/MetaProperty";
 
 describe('AuthoringUtils ->', () => {
     let authoringUtils: AuthoringUtils;
@@ -105,23 +106,30 @@ describe('AuthoringUtils ->', () => {
     describe('isEditMode', () => {
         it('should be false if both indicators are falsy', () => {
             jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
-            jest.spyOn<any, string>(AuthoringUtils, 'getWCMModeFromURL').mockReturnValue(null);
+            jest.spyOn<any, string>(PathUtils, 'getCurrentURL').mockReturnValue('');
 
             assert.ok(AuthoringUtils.isEditMode() === false);
         });
 
         it('should be true based on meta property', () => {
             jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
-            jest.spyOn<any, string>(AuthoringUtils, 'getWCMModeFromURL').mockReturnValue(null);
+            jest.spyOn<any, string>(PathUtils, 'getCurrentURL').mockReturnValue('');
 
             assert.ok(AuthoringUtils.isEditMode());
         });
 
         it('should be true based on meta property', () => {
             jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
-            jest.spyOn<any, string>(AuthoringUtils, 'getWCMModeFromURL').mockReturnValue(AEM_MODE.EDIT);
+            jest.spyOn<any, string>(PathUtils, 'getCurrentURL').mockReturnValue('http://localhost/?' + MetaProperty.WCM_MODE + '=' + AEM_MODE.EDIT);
 
             assert.ok(AuthoringUtils.isEditMode());
+        });
+
+        it('should be false when url is malformed and metaproperty not edit', () => {
+            jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
+            jest.spyOn<any, string>(PathUtils, 'getCurrentURL').mockReturnValue('a/b');
+
+            assert.ok(!AuthoringUtils.isEditMode());
         });
     });
 

--- a/test/AuthoringUtils.test.ts
+++ b/test/AuthoringUtils.test.ts
@@ -41,8 +41,8 @@ describe('AuthoringUtils ->', () => {
 
         it('should return DocumentFragment based on AuthoringUtils.AUTHORING_LIBRARIES', () => {
             // given
+            jest.spyOn(AuthoringUtils, 'isRemoteApp').mockReturnValue(true);
             jest.spyOn(AuthoringUtils, 'isEditMode').mockReturnValue(true);
-
             // when
 
             const libs: DocumentFragment = authoringUtils.getAemLibraries();
@@ -57,6 +57,7 @@ describe('AuthoringUtils ->', () => {
         describe('scripts', () => {
             it('should contain proper script tags', () => {
                 // given
+                jest.spyOn(AuthoringUtils, 'isRemoteApp').mockReturnValue(true);
                 jest.spyOn(AuthoringUtils, 'isEditMode').mockReturnValue(true);
                 // when
 
@@ -104,21 +105,21 @@ describe('AuthoringUtils ->', () => {
     describe('isEditMode', () => {
         it('should be false if both indicators are falsy', () => {
             jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
-            jest.spyOn<any, string>(AuthoringUtils, 'getAemMode').mockReturnValue(null);
+            jest.spyOn<any, string>(AuthoringUtils, 'getWCMModeFromURL').mockReturnValue(null);
 
             assert.ok(AuthoringUtils.isEditMode() === false);
         });
 
         it('should be true based on meta property', () => {
             jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
-            jest.spyOn<any, string>(AuthoringUtils, 'getAemMode').mockReturnValue(null);
+            jest.spyOn<any, string>(AuthoringUtils, 'getWCMModeFromURL').mockReturnValue(null);
 
             assert.ok(AuthoringUtils.isEditMode());
         });
 
         it('should be true based on meta property', () => {
             jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
-            jest.spyOn<any, string>(AuthoringUtils, 'getAemMode').mockReturnValue(AEM_MODE.EDIT);
+            jest.spyOn<any, string>(AuthoringUtils, 'getWCMModeFromURL').mockReturnValue(AEM_MODE.EDIT);
 
             assert.ok(AuthoringUtils.isEditMode());
         });

--- a/test/AuthoringUtils.test.ts
+++ b/test/AuthoringUtils.test.ts
@@ -12,9 +12,8 @@
 
 import * as assert from 'assert';
 import { AuthoringUtils } from '../src/AuthoringUtils';
-import {PathUtils} from "../src/PathUtils";
-import {AEM_MODE} from "../src/Constants";
-
+import { PathUtils } from '../src/PathUtils';
+import { AEM_MODE } from '../src/Constants';
 
 describe('AuthoringUtils ->', () => {
     let authoringUtils: AuthoringUtils;


### PR DESCRIPTION
- Removed "Authoring mode", as there is no notion of it anywhere.
- Changed generated libs string to DocumentFragment, appending html string doesn't work for link and script elements.
- Added meta wcm:mode=json tag 
- Limited boilerplate required for user code
- Provided alternative way, to generate own html tags