### PR TITLE
fix: update regex for remote app routing transform

### DIFF
--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -533,8 +533,8 @@ export class PathUtils {
         const isLoadedInAEM = window.location.origin === aemHost;
 
         if (isLoadedInAEM) {
-            // Remove trailing slashes, if any
-            rootPath = rootPath.replace(/\/*$/, '');
+            // Remove leading and trailing slashes, if any
+            rootPath = rootPath.replace(/^\/|\/$/g, '');
 
             // editor.html - Not present in publish view
             // aem project path - Optional in publish view. Could be removed if navigating within the app via links
@@ -542,6 +542,7 @@ export class PathUtils {
 
             if (path.indexOf(aemPathPrefix) < 0) {
                 const newPath = (`${aemPathPrefix}${path}(.html)?`);
+
                 return newPath;
             }
         }

--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -519,17 +519,25 @@ export class PathUtils {
 
     /**
      * Helper for handling remote react app routing in edit mode
+     *
+     * When an external SPA is opened in the editor, the router needs updated path parameter
+     * to account for the AEM specific prefix in the URL
+     * eg: /home will become /content/{aem_project_name}/home
+     *
      * @param path Path to route to
      * @param aemHost Origin information of the AEM instance in which to edit
      * @param rootPath AEM path which forms the root path of the remote app
-     * @returns Updated url
+     * @returns Updated path to match against
      */
     public static toAEMPath(path: string, aemHost: string, rootPath: string): string {
         const isLoadedInAEM = window.location.origin === aemHost;
 
         if (isLoadedInAEM) {
-            // Remove trailing slash, if any
-            rootPath = rootPath.replace(/\/$/, '');
+            // Remove trailing slashes, if any
+            rootPath = rootPath.replace(/\/*$/, '');
+
+            // editor.html - Not present in publish view
+            // aem project path - Optional in publish view. Could be removed if navigating within the app via links
             const aemPathPrefix = `(/editor.html)?(/content/${rootPath})?`;
 
             if (path.indexOf(aemPathPrefix) < 0) {

--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -528,11 +528,12 @@ export class PathUtils {
         const isLoadedInAEM = window.location.origin === aemHost;
 
         if (isLoadedInAEM) {
-            const aemPathPrefix = `(/editor.html)?/content/${rootPath}`;
+            // Remove trailing slash, if any
+            rootPath = rootPath.replace(/\/$/, '');
+            const aemPathPrefix = `(/editor.html)?(/content/${rootPath})?`;
 
             if (path.indexOf(aemPathPrefix) < 0) {
-                const newPath = normalizePath(`${aemPathPrefix}/${path}(.html)?`);
-
+                const newPath = (`${aemPathPrefix}${path}(.html)?`);
                 return newPath;
             }
         }

--- a/test/PathUtils.test.ts
+++ b/test/PathUtils.test.ts
@@ -471,5 +471,21 @@ describe('PathUtils ->', () => {
 
             expect(REMOTE_APP_PAGE).toMatch(newPathPattern);
         });
+        it('matches react app path when root path is provided in a different pattern', () => {
+            const AEM_PROJECT_PATH = '/testproj/lang/';
+
+            // Transform to match AEM path when running on AEM instance
+            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, aemOrigin, AEM_PROJECT_PATH));
+
+            expect(AEM_PAGE_PATH).toMatch(newPathPattern);
+        });
+        it('matches react app path when app path is navigated to in publish view', () => {
+            const AEM_PROJECT_PATH = '/testproj/lang/';
+
+            // Transform to match AEM path if navigated within app on AEM instance
+            const newPathPattern = new RegExp(PathUtils.toAEMPath(REMOTE_APP_PAGE, aemOrigin, AEM_PROJECT_PATH));
+
+            expect(REMOTE_APP_PAGE).toMatch(newPathPattern);
+        });
     });
 });


### PR DESCRIPTION
## Description

Updated util function for handling routing of remote apps in AEM - 
- Removed trailing slashes
- AEM prefix made optional to account for publish/vanity urls


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
