### PR TITLE
fix: Exporting AuthoringUtils required for remote app

### DIFF
--- a/src/AuthoringUtils.ts
+++ b/src/AuthoringUtils.ts
@@ -142,6 +142,17 @@ export class AuthoringUtils {
     }
 
     /**
+     * Checks if preview mode is on.
+     * @returns `true` if application is in AEM `PREVIEW` mode.
+     */
+    public static isPreviewMode(): boolean {
+        const viaMetaProperty = PathUtils.getMetaPropertyValue(MetaProperty.WCM_MODE) === AEM_MODE.PREVIEW;
+        const viaQueryParam = PathUtils.isBrowser() && (AuthoringUtils.getWCMModeFromURL() === AEM_MODE.PREVIEW);
+
+        return viaMetaProperty || viaQueryParam;
+    }
+
+    /**
      * Checks if app is a remote application.
      * If the cq:wcmmode is provided as get parameter it is implied that the app is remote.
      * @returns `true` if the application is a remote app.
@@ -191,5 +202,13 @@ export class AuthoringUtils {
         });
 
         return result;
+    }
+
+    /**
+     * Is the app used in the context of the AEM Page editor or it is a remote application.
+     * @returns 'true' if app is in Editor 
+     */
+    public static isInEditor(): boolean {
+        return AuthoringUtils.isEditMode() || AuthoringUtils.isPreviewMode() || AuthoringUtils.isRemoteApp();
     }
 }

--- a/src/AuthoringUtils.ts
+++ b/src/AuthoringUtils.ts
@@ -130,15 +130,19 @@ export class AuthoringUtils {
         return docFragment;
     }
 
+    private static isMode(mode: string): boolean {
+        const viaMetaProperty = PathUtils.getMetaPropertyValue(MetaProperty.WCM_MODE) === mode;
+        const viaQueryParam = PathUtils.isBrowser() && (AuthoringUtils.getWCMModeFromURL() === mode);
+
+        return viaMetaProperty || viaQueryParam;
+    }
+
     /**
      * Checks if edit mode is on.
      * @returns `true` if application is in AEM `EDIT` mode.
      */
     public static isEditMode(): boolean {
-        const viaMetaProperty = PathUtils.getMetaPropertyValue(MetaProperty.WCM_MODE) === AEM_MODE.EDIT;
-        const viaQueryParam = PathUtils.isBrowser() && (AuthoringUtils.getWCMModeFromURL() === AEM_MODE.EDIT);
-
-        return viaMetaProperty || viaQueryParam;
+        return AuthoringUtils.isMode(AEM_MODE.EDIT);
     }
 
     /**
@@ -146,10 +150,7 @@ export class AuthoringUtils {
      * @returns `true` if application is in AEM `PREVIEW` mode.
      */
     public static isPreviewMode(): boolean {
-        const viaMetaProperty = PathUtils.getMetaPropertyValue(MetaProperty.WCM_MODE) === AEM_MODE.PREVIEW;
-        const viaQueryParam = PathUtils.isBrowser() && (AuthoringUtils.getWCMModeFromURL() === AEM_MODE.PREVIEW);
-
-        return viaMetaProperty || viaQueryParam;
+        return AuthoringUtils.isMode(AEM_MODE.PREVIEW);
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,4 +16,5 @@ export { default as ModelManager } from './ModelManager';
 export * from './ModelClient';
 export * from './Model';
 export * from './PathUtils';
+export * from './AuthoringUtils';
 export { AEM_MODE, default as Constants } from './Constants';

--- a/test/AuthoringUtils.test.ts
+++ b/test/AuthoringUtils.test.ts
@@ -133,4 +133,35 @@ describe('AuthoringUtils ->', () => {
         });
     });
 
+
+    describe('isPreviewMode', () => {
+        it('should be false if both indicators are falsy', () => {
+            jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
+            jest.spyOn<any, string>(PathUtils, 'getCurrentURL').mockReturnValue('');
+
+            assert.ok(AuthoringUtils.isPreviewMode() === false);
+        });
+
+        it('should be true based on meta property', () => {
+            jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.PREVIEW);
+            jest.spyOn<any, string>(PathUtils, 'getCurrentURL').mockReturnValue('');
+
+            assert.ok(AuthoringUtils.isPreviewMode());
+        });
+
+        it('should be true based on meta property', () => {
+            jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
+            jest.spyOn<any, string>(PathUtils, 'getCurrentURL').mockReturnValue('http://localhost/?' + MetaProperty.WCM_MODE + '=' + AEM_MODE.PREVIEW);
+
+            assert.ok(AuthoringUtils.isPreviewMode());
+        });
+
+        it('should be false when url is malformed and metaproperty not edit', () => {
+            jest.spyOn(PathUtils, 'getMetaPropertyValue').mockReturnValue(AEM_MODE.EDIT);
+            jest.spyOn<any, string>(PathUtils, 'getCurrentURL').mockReturnValue('a/b');
+
+            assert.ok(!AuthoringUtils.isPreviewMode());
+        });
+    });
+
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Exposing Authoring utils to be used in related PR https://github.com/adobe/aem-react-editable-components/pull/51
- Adding function to check if application is in editor 
- Adding function to check if application is in 'PREVIEW' mode

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
