### PR TITLE
fix: wait for dynamic editor libs to load in editor mode

### DIFF
--- a/src/AuthoringUtils.ts
+++ b/src/AuthoringUtils.ts
@@ -85,6 +85,26 @@ export class AuthoringUtils {
         return docFragment;
     }
 
+    /**
+     * Triggers callback when synchronous src tags in the document fragment have been loaded.
+     * Resolves automatically when there are no scripts.
+     *
+     * @param docFragment HTMLElements aggregate
+     * @param callback
+     */
+    public setOnLoadCallback(docFragment: DocumentFragment, callback: () => void) {
+        const scriptTags = docFragment.querySelectorAll('script');
+
+        if (!scriptTags.length) {
+            callback();
+        } else {
+            scriptTags[scriptTags.length - 1].onload = () => {
+                callback();
+            };
+        }
+
+    }
+
     private generateMetaElements(metaInfo: {[key :string]:string}) :DocumentFragment {
         const docFragment: DocumentFragment = document.createDocumentFragment();
 
@@ -207,7 +227,7 @@ export class AuthoringUtils {
 
     /**
      * Is the app used in the context of the AEM Page editor or it is a remote application.
-     * @returns 'true' if app is in Editor 
+     * @returns 'true' if app is in Editor
      */
     public static isInEditor(): boolean {
         return AuthoringUtils.isEditMode() || AuthoringUtils.isPreviewMode() || AuthoringUtils.isRemoteApp();


### PR DESCRIPTION
## Description

In case editor libs (page.js and so on) are loaded dynamically. The execution must wait untill the scripts trigger load event.

## Motivation and Context

The problem was when pagemodel was loaded, an event triggered and there was nobody yet (i.e message.js from editor's package) to listen to this event. 

## How Has This Been Tested?

Manual + automated tests
More tests to come

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
