### PR TITLE
fix: allow fragment part in the url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aem-spa-page-model-manager",
-  "version": "1.3.0",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -241,8 +241,9 @@ export class PathUtils {
         // 1. the resource
         // 2. the selectors and the extension
         // 3. the suffix
-        // 4. the parameters
-        const match = /^((?:[/a-zA-Z0-9:_-]*)+)(?:\.?)([a-zA-Z0-9._-]*)(?:\/?)([a-zA-Z0-9/._-]*)(?:\??)([a-zA-Z0-9=&]*)$/g.exec(
+        // 4. the query
+        // 5. the fragment
+        const match = /^((?:[/a-zA-Z0-9:%_-]*)+)(?:\.?)([a-zA-Z0-9.%_-]*)(?:\/?)([a-zA-Z0-9/.%:_-]*)(?:\??)(([a-zA-Z0-9._~\-!$&'()*+,;=:@?/]|(%[0-9A-Fa-f]{2}))*)(?:#?)(([a-zA-Z0-9._~\-!$&'()*+,;=:@?/]|(%[0-9A-Fa-f]{2}))*)$/g.exec(
             path
         );
 

--- a/test/PathUtils.test.ts
+++ b/test/PathUtils.test.ts
@@ -402,6 +402,7 @@ describe('PathUtils ->', () => {
         assert.equal(PathUtils.addExtension('/foobar.xyz', 'html'), '/foobar.xyz.html');
         assert.equal(PathUtils.addExtension('/foobar.json', 'json'), '/foobar.json');
         assert.equal(PathUtils.addExtension('/foobar', 'json'), '/foobar.json');
+        assert.equal(PathUtils.addExtension('/foobar#test123fragment', 'model.json'), '/foobar.model.json');
     });
 
     it('addSelector', () => {


### PR DESCRIPTION
Added fragment section to regex as per
https://tools.ietf.org/html/rfc3986#section-3.5

(it is the same as query, but starts with # instead of ?)

## Related Issue

https://github.com/adobe/aem-spa-page-model-manager/issues/39

## How Has This Been Tested?

Unit tested, smoke tested

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
