### PR TITLE
fix: Return correct model path on route change

### DIFF
--- a/src/ModelRouter.ts
+++ b/src/ModelRouter.ts
@@ -74,20 +74,10 @@ export class RouterModes {
  * @private
  * @return
  */
-export function getModelPath(url?: string | null): string {
+export function getModelPath(url?: string | null): string | null {
     const localUrl = url || window.location.pathname;
 
-    // The default value model path comes as the the content path
-    let endPosition = localUrl.indexOf('.');
-
-    if (endPosition < 0) {
-        // If the path is missing extension and has query params instead eg. http://zyx/abc?test=test
-        const queryPosition = localUrl.indexOf('?');
-
-        endPosition = (queryPosition < 0) ? localUrl.length : queryPosition;
-    }
-
-    return localUrl.substr(0, endPosition);
+    return PathUtils.sanitize(localUrl);
 }
 
 /**

--- a/test/ModelRouter.test.ts
+++ b/test/ModelRouter.test.ts
@@ -43,6 +43,10 @@ describe('ModelRouter ->', () => {
         it('should get the current window URL', () => {
             expect(getModelPath('/zyx/abc?test=test')).toEqual('/zyx/abc');
         });
+
+        it('should get the current window URL', () => {
+            expect(getModelPath('/zyx/abc?date=03.10.2021')).toEqual('/zyx/abc');
+        });
     });
 
     describe('dispatchRouteChanged ->', () => {


### PR DESCRIPTION
Return correct model path for a URL with query parameters that include dot character on route change

## Description

PathUtils.sanitize method reused to get a correct model path from URL on route change

## Related Issue

#53

## How Has This Been Tested?

Unit tested

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
