### PR TITLE
fix: handle excluded route path on ModelManager initialize

### DIFF
--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -18,6 +18,7 @@ import { ModelClient } from './ModelClient';
 import { ModelStore } from './ModelStore';
 import { PathUtils } from './PathUtils';
 import { AuthoringUtils } from './AuthoringUtils';
+import { isRouteExcluded } from './ModelRouter';
 
 /**
  * Checks whether provided child path exists in the model.
@@ -342,6 +343,7 @@ export class ModelManager {
         if (
             !!currentPathname &&
             !!sanitizedCurrentPathname && // active page path is available for fetching model
+            !isRouteExcluded(currentPathname) &&
             !isPageURLRoot(currentPathname, metaPropertyModelURL) && // verify currently active URL is not same as the URL of the root model
             !hasChildOfPath(rootModel, currentPathname) // verify fetched root model doesn't already contain the active path model
         ) {
@@ -350,6 +352,8 @@ export class ModelManager {
 
                 return this._fetchPageModelFromStore();
             });
+        } else if (!!currentPathname && isRouteExcluded(currentPathname)) {
+            return this._fetchPageModelFromStore();
         } else if (!PathUtils.isBrowser()) {
             throw new Error(`Attempting to retrieve model data from a non-browser.
                 Please provide the initial data with the property key model`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Based on the current implementation, we cannot access the excluded sub page route path on initialize. This is because we are not considering the excluded filter paths on Model Manger initialize. 

## Related Issue

#56 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
