### PR TITLE
Feature/error pages

### DIFF
--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -452,10 +452,15 @@ export class ModelManager {
                     delete this._fetchPromises[path];
 
                     if (this._errorPageRoot !== undefined) {
-                        const errorPagePath = this._errorPageRoot + error.response.status + '.model.json';
+
+                        const code = typeof error !== 'string' && error.response ? error.response.status : '500';
+                        const errorPagePath = this._errorPageRoot + code + '.model.json';
 
                         if (path.indexOf('jcr:content') === -1 && path !== errorPagePath) {
-                            this._fetchData(errorPagePath).then(resolve).catch(reject);
+                            this._fetchData(errorPagePath).then(( response => {
+                                response[Constants.PATH_PROP] = PathUtils.sanitize(path) || path;
+                                resolve(response);
+                            })).catch(reject);
                         } else {
                             reject(error);
                         }

--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -434,7 +434,7 @@ export class ModelManager {
 
         if (this.modelClient) {
 
-            const wrapperPromise = new Promise<Model>((resolve,reject) => {
+            return new Promise<Model>((resolve, reject) => {
 
                 const promise = this.modelClient.fetch(this._toModelPath(path));
 
@@ -445,19 +445,17 @@ export class ModelManager {
                     if (this._isRemoteApp()) {
                         triggerPageModelLoaded(obj);
                     }
-
                     resolve(obj);
                 }).catch((error) => {
 
                     delete this._fetchPromises[path];
-
                     if (this._errorPageRoot !== undefined) {
 
                         const code = typeof error !== 'string' && error.response ? error.response.status : '500';
                         const errorPagePath = this._errorPageRoot + code + '.model.json';
 
-                        if (path.indexOf('jcr:content') === -1 && path !== errorPagePath) {
-                            this._fetchData(errorPagePath).then(( response => {
+                        if (path.indexOf(Constants.JCR_CONTENT) === -1 && path !== errorPagePath) {
+                            this._fetchData(errorPagePath).then((response => {
                                 response[Constants.PATH_PROP] = PathUtils.sanitize(path) || path;
                                 resolve(response);
                             })).catch(reject);
@@ -470,8 +468,6 @@ export class ModelManager {
                 });
 
             });
-
-            return wrapperPromise;
         } else {
             throw new Error('ModelClient not initialized!');
         }

--- a/test/ModelManager.test.ts
+++ b/test/ModelManager.test.ts
@@ -208,7 +208,7 @@ describe('ModelManager ->', () => {
 
                 return Promise.all(promises).then(() => {
                     for (let i = 0; i < promises.length - 1; ++i) {
-                        assert.equal(promises[i], promises[i + 1]);
+                        expect(promises[i]).toEqual(promises[i + 1]);
                     }
                 });
             });

--- a/test/ModelManager.test.ts
+++ b/test/ModelManager.test.ts
@@ -92,7 +92,8 @@ describe('ModelManager ->', () => {
         when(ModelClientMock.fetch(anyString())).thenReturn(Promise.resolve(PAGE_MODEL));
         when(ModelClientMock.fetch(PAGE_MODEL_URL)).thenReturn(Promise.resolve(PAGE_MODEL));
         when(ModelClientMock.fetch(CHILD_MODEL_URL)).thenReturn(Promise.resolve(content_test_page_root_child0000_child0010));
-        when(ModelClientMock.fetch(NON_EXISTING_MODEL_URL)).thenReturn(Promise.reject({ response: { status: 404, statusText: 'Could not find page' } }));
+        when(ModelClientMock.fetch(NON_EXISTING_MODEL_URL))
+            .thenReturn(Promise.reject({ response: { status: 404, statusText: 'Could not find page' } }));
         when(ModelClientMock.fetch(ERROR_MODEL_URL)).thenReturn(Promise.reject('Some Error without json'));
 
         when(ModelClientMock.fetch(ERROR_MODEL_URL_404)).thenReturn(Promise.resolve(ERROR_PAGE_MODEL_404));

--- a/test/data/MainPageData.ts
+++ b/test/data/MainPageData.ts
@@ -132,3 +132,42 @@ export const PAGE_MODEL: PageModel = {
     ':path': '/content/test/page',
     ':type': 'we-retail-react/components/structure/page'
 };
+
+export const ERROR_PAGE_MODEL_404: PageModel = {
+    'designPath': '/libs/settings/wcm/designs/default',
+    'title': 'Example Error Page 404',
+    'lastModifiedDate': 1512116041058,
+    'templateName': 'sample-template',
+    'cssClassNames': 'page',
+    'language': 'en-US',
+    ':itemsOrder': [
+        'root'
+    ],
+    ':items': {
+        'root': content_test_page_root
+    },
+    ':hierarchyType': 'page',
+    ':children': {},
+    ':path': '/content/test/page',
+    ':type': 'we-retail-react/components/structure/page'
+};
+
+
+export const ERROR_PAGE_MODEL_500: PageModel = {
+    'designPath': '/libs/settings/wcm/designs/default',
+    'title': 'Example Error Page 500',
+    'lastModifiedDate': 1512116041058,
+    'templateName': 'sample-template',
+    'cssClassNames': 'page',
+    'language': 'en-US',
+    ':itemsOrder': [
+        'root'
+    ],
+    ':items': {
+        'root': content_test_page_root
+    },
+    ':hierarchyType': 'page',
+    ':children': {},
+    ':path': '/content/test/page',
+    ':type': 'we-retail-react/components/structure/page'
+};


### PR DESCRIPTION
Provides the possibility to specify error pages (500,404) pages for the SPA editor. compatible with  https://adobe-consulting-services.github.io/acs-aem-commons/features/error-handler/index.html.

![Screenshot 2021-06-29 at 10 11 39](https://user-images.githubusercontent.com/26429828/123761745-684c0680-d8c2-11eb-8a78-3ce234549dd7.png)
![Screenshot 2021-06-29 at 10 11 22](https://user-images.githubusercontent.com/26429828/123761696-5d917180-d8c2-11eb-8429-044c011f8669.png)


![Screenshot 2021-06-29 at 10 10 38](https://user-images.githubusercontent.com/26429828/123761608-43579380-d8c2-11eb-98e0-08dac87e6f50.png)
