### PR TITLE
fix: fix html extension regex

### DIFF
--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -228,8 +228,6 @@ export class PathUtils {
      * @param extension - Extension to be added.
      */
     public static addExtension(path: string, extension: string): string {
-        console.log(path);
-        console.log(extension);
         if (!extension || extension.length < 1) {
             return path;
         }
@@ -284,7 +282,7 @@ export class PathUtils {
 
         const slingElementsWithoutResource = pathWithoutResource.split('/');
         const selectors = slingElementsWithoutResource[0].split('.');
-        let currentExtension = selectors.pop() || '';
+        let currentExtension = selectors.pop();
 
         currentExtension = currentExtension ? currentExtension.replace(/htm(l)?/, '') : '';
 

--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -228,6 +228,8 @@ export class PathUtils {
      * @param extension - Extension to be added.
      */
     public static addExtension(path: string, extension: string): string {
+        console.log(path);
+        console.log(extension);
         if (!extension || extension.length < 1) {
             return path;
         }
@@ -282,9 +284,9 @@ export class PathUtils {
 
         const slingElementsWithoutResource = pathWithoutResource.split('/');
         const selectors = slingElementsWithoutResource[0].split('.');
-        let currentExtension = selectors.pop();
+        let currentExtension = selectors.pop() || '';
 
-        currentExtension = currentExtension ? currentExtension.replace(/\.htm(l)?/, '') : '';
+        currentExtension = currentExtension ? currentExtension.replace(/htm(l)?/, '') : '';
 
         let path = selectors.join('.') + '.' + currentExtension + extension;
 

--- a/test/PathUtils.test.ts
+++ b/test/PathUtils.test.ts
@@ -403,6 +403,7 @@ describe('PathUtils ->', () => {
         assert.equal(PathUtils.addExtension('/foobar.json', 'json'), '/foobar.json');
         assert.equal(PathUtils.addExtension('/foobar', 'json'), '/foobar.json');
         assert.equal(PathUtils.addExtension('/foobar#test123fragment', 'model.json'), '/foobar.model.json');
+        assert.equal(PathUtils.addExtension('/foobar.model.html', 'json'), '/foobar.model.json');
     });
 
     it('addSelector', () => {


### PR DESCRIPTION
## Description

The extension is retrieved by splitting the path by "." and would no longer be present in the value
compared against regex

## Related Issue

fixes #64


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
