### PR TITLE
fix(bugfix): [#82] make npm run build:production produce dist/types.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "types": "dist/types.d.ts",
   "scripts": {
     "build:production": "NODE_ENV=production npm run build",
-    "build:types": "tsc -p tsconfig.types.json",
-    "build": "npm run clean && npm run lint && npm run build:types && webpack",
+    "build:types": "tsc -p src/tsconfig.types.json",
+    "build": "npm run clean && npm run lint && webpack && npm run build:types",
     "clean": "rm -rf dist/",
     "docs": "npm i && npx typedoc --excludePrivate ./src --out ./dist/docs",
     "lint": "eslint .",

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-    "extends": "./tsconfig.json",
+    "extends": "../tsconfig.json",
     "compilerOptions": {
         "noEmit": false,
         "baseUrl": ".",

--- a/src/tsconfig.types.json
+++ b/src/tsconfig.types.json
@@ -8,7 +8,7 @@
         "removeComments": false,
         "declaration": true,
         "declarationMap": true,
-        "declarationDir": "./dist",
+        "declarationDir": "../dist",
         "emitDeclarationOnly": true
     },
     "exclude": [


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for bug [ #82]
Moved tsconfig.types.json to src and fixed build script in package.json to product dist/typs.d.ts on `npm build:production`


## How Has This Been Tested?
`npm run build:production && ls -lha dist/types.d.ts`
`npm run test` << all tests passed

## Types of changes
- [ #82] 